### PR TITLE
Added infinite-ish scroll feature

### DIFF
--- a/src/react-elastic-carousel/components/__tests__/Carousel.test.js
+++ b/src/react-elastic-carousel/components/__tests__/Carousel.test.js
@@ -50,12 +50,6 @@ describe("Carousel - public API (props)", () => {
     expect(slider.props().isRTL).toEqual(true);
   });
 
-  it("infinite", () => {
-    const wrapper = shallow(<Carousel infinite>{Items}</Carousel>);
-    const slider = wrapper.find(Slider);
-    expect(slider.props().infinite).toEqual(true);
-  });
-
   it("pagination", () => {
     const wrapper = shallow(<Carousel pagination>{Items}</Carousel>);
     const pagination = wrapper.find(Pagination);

--- a/src/react-elastic-carousel/components/__tests__/Carousel.test.js
+++ b/src/react-elastic-carousel/components/__tests__/Carousel.test.js
@@ -50,6 +50,12 @@ describe("Carousel - public API (props)", () => {
     expect(slider.props().isRTL).toEqual(true);
   });
 
+  it("infinite", () => {
+    const wrapper = shallow(<Carousel infinite>{Items}</Carousel>);
+    const slider = wrapper.find(Slider);
+    expect(slider.props().infinite).toEqual(true);
+  });
+
   it("pagination", () => {
     const wrapper = shallow(<Carousel pagination>{Items}</Carousel>);
     const pagination = wrapper.find(Pagination);


### PR DESCRIPTION
Implemented an infinite scroll option as mentioned in #9 

@sag1v I know you mentioned adding copies to make it _actually_ appear to be infinite, but I think this is a good start for now for anyone who wants to use it as is. I personally don't mind the backwards scroll.

Seems like creating copies would be very inefficient, but I don't see a way to easily get around that.

Since it's not truly infinite, it will stop on the first/last item when it has potential to scroll past it. Here's an example:

![infinite scroll example](https://user-images.githubusercontent.com/19353967/59140866-48f38100-8969-11e9-95eb-9944ede74bae.gif)

I had issues trying to put together a demo page, so I left that mess out, but I did test it out on the current demos.

Let me know what you think!