### PR TITLE
Conditionalize the min height to vertical mode

### DIFF
--- a/src/react-elastic-carousel/components/styled/Slider.js
+++ b/src/react-elastic-carousel/components/styled/Slider.js
@@ -51,7 +51,7 @@ export default styled.div`
   position: absolute;
   display: flex;
   flex-direction: ${({ verticalMode }) => (verticalMode ? "column" : "row")};
-  min-height: 100%;
+  ${({ verticalMode }) => (verticalMode ? "min-height: 100%;" : "")}
   transition: ${calcTransition};
   left: ${calcLeft};
   right: ${calcRight};


### PR DESCRIPTION
This fixes an issue where if the slides get smaller than the initial
height, the carousel won't shrink.