### PR TITLE
Add missing property isEdge in RenderArrowProps

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -3,6 +3,7 @@ import React from "react";
 type RenderArrowProps = {
   type: "PREV" | "NEXT";
   onClick: () => void;
+  isEdge: boolean;
 };
 
 type RenderPaginationProps = {


### PR DESCRIPTION
Added missing property `isEdge` to be able to use the suggested code examples on: https://sag1v.github.io/react-elastic-carousel/renderArrow