### PR TITLE
Correct misspelled word activatePage -> activePage

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -8,7 +8,7 @@ type RenderArrowProps = {
 
 type RenderPaginationProps = {
   pages: number;
-  activatePage: number;
+  activePage: number;
   // The onClick event that sets the state of the carousel and sends
   // it to a specific page.
   onClick: (indicatorId: string) => void;


### PR DESCRIPTION
If the spelling was not corrected typescript throws an error that activePage does not match/exists