### PR TITLE
fix regression due to #122

### DIFF
--- a/src/react-elastic-carousel/components/Carousel.js
+++ b/src/react-elastic-carousel/components/Carousel.js
@@ -274,7 +274,9 @@ class Carousel extends React.Component {
             // we are making sure the selected index is not out of boundaries and respecting itemsToShow
             // This usually happens with breakpoints. see https://github.com/sag1v/react-elastic-carousel/issues/122
             let activeIndex = currentState.activeIndex;
-            const endLimit = childrenLength - itemsToShow;
+            // we take the lowest, in case itemsToShow is greater than childrenLength
+            const maxItemsToShow = Math.min(childrenLength, itemsToShow)
+            const endLimit = childrenLength - maxItemsToShow;
             if (activeIndex > endLimit) {
               activeIndex = endLimit;
             }


### PR DESCRIPTION
#122 introduced a new bug when `itemsLength` was lower than `itemsToShow` (offset slider position). This PR fixes the bug