### PR TITLE
Mark isRTL member Optional #181

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -34,7 +34,7 @@ export interface ReactElasticCarouselProps {
   // Defaults to false
   verticalMode?: boolean;
   // Defaults to false
-  isRTL: boolean;
+  isRTL?: boolean;
   // Defaults to true
   pagination?: boolean;
   // Defaults to 500


### PR DESCRIPTION
# Description

With this merge, the annoying warning raised by linter about isRTL being a required prop (even though it isn't) will be fixed.

fixes #181 