### PR TITLE
Remove id from ItemWrapper causing duplicate id attributes if more than one carousel is on a page.

### DIFF
--- a/src/react-elastic-carousel/components/ItemWrapperContainer.js
+++ b/src/react-elastic-carousel/components/ItemWrapperContainer.js
@@ -5,8 +5,8 @@ import { noop } from "../utils/helpers";
 
 class ItemWrapperContainer extends React.Component {
   onClick = () => {
-    const { onClick, id } = this.props;
-    onClick(id);
+    const { onClick, key } = this.props;
+    onClick(key);
   };
   render() {
     return <ItemWrapper {...this.props} onClick={this.onClick} />;
@@ -18,7 +18,7 @@ ItemWrapperContainer.defaultProps = {
 };
 
 ItemWrapperContainer.propTypes = {
-  id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  key: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onClick: PropTypes.func
 };
 

--- a/src/react-elastic-carousel/components/Track.js
+++ b/src/react-elastic-carousel/components/Track.js
@@ -50,7 +50,6 @@ const Track = ({
         )}
       >
         <ItemWrapperContainer
-          id={idx}
           itemPosition={itemPosition}
           style={{ width, padding: paddingStyle }}
           key={idx}


### PR DESCRIPTION
The ItemWrapper has an id attribute of the index of the carousel it is inside.
If more than one carousel is on a page, then duplicate id's on the page can occur, thus creating a11y issues. 

I propose using the key in the click event instead of an id attribute and removing passing down id, so we don't create the duplicate id's.

Feel free to ask any questions!
Thanks!