### PR TITLE
Fixing children prop bug

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -22,6 +22,11 @@ export type ItemObject = {
   index: number;
 };
 
+export type Children = {
+  array: any;
+  index:number
+};
+
 export type Breakpoint = {
   itemsToScroll: number;
   itemsToShow: number;
@@ -106,6 +111,8 @@ export interface ReactElasticCarouselProps {
   onPrevEnd?: (nextItemObject: ItemObject, currentPageIndex: number) => void;
   // A callback for the "slider-container" resize
   onResize?: (currentBreakpoint: Breakpoint) => void;
+  // A prop for carousel items
+  children: React.ReactNode
 }
 
 declare class ReactElasticCarousel extends React.Component<


### PR DESCRIPTION
In this Pull request, a children prop bug has been fixed which appeared when writing this carousel element in the typescript file. In the file named index.d.ts at 110 a children prop has been added to fix that bug as shown in the screenshots below:
<img width="1440" alt="Screenshot 2023-02-08 at 9 13 03 PM" src="https://user-images.githubusercontent.com/87875062/217621394-84091a9f-6190-489f-9e73-66c66190dd32.png">
<img width="1440" alt="Screenshot 2023-02-08 at 9 13 13 PM" src="https://user-images.githubusercontent.com/87875062/217621410-dfb20074-dbf4-411d-9994-97c3c3e88b8d.png">
