### PR TITLE
Fixing children prop bug

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -1,6 +1,6 @@
 /* eslint no-unused-vars: 0 */ // --> OFF
 /* eslint no-undef: 0 */ // --> OFF
-import * as React from "react";
+import React, {ReactNode} from "react";
 
 export type RenderArrowProps = {
   type: "PREV" | "NEXT";
@@ -32,7 +32,7 @@ export type Breakpoint = {
   itemsToShow: number;
 };
 
-export interface ReactElasticCarouselProps {
+export i ReactElasticCarouselProps {
   className?: string;
   // Defaults to 1
   itemsToShow?: number;

--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -22,17 +22,12 @@ export type ItemObject = {
   index: number;
 };
 
-export type Children = {
-  array: any;
-  index:number
-};
-
 export type Breakpoint = {
   itemsToScroll: number;
   itemsToShow: number;
 };
 
-export i ReactElasticCarouselProps {
+export interface ReactElasticCarouselProps {
   className?: string;
   // Defaults to 1
   itemsToShow?: number;

--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -22,6 +22,11 @@ export type ItemObject = {
   index: number;
 };
 
+export type Children = {
+  array: any;
+  index:number
+};
+
 export type Breakpoint = {
   itemsToScroll: number;
   itemsToShow: number;
@@ -106,6 +111,8 @@ export interface ReactElasticCarouselProps {
   onPrevEnd?: (nextItemObject: ItemObject, currentPageIndex: number) => void;
   // A callback for the "slider-container" resize
   onResize?: (currentBreakpoint: Breakpoint) => void;
+  // A prop for carousel items
+  children: React.ReactNode
 }
 
 declare class ReactElasticCarousel extends React.Component<


### PR DESCRIPTION
In this Pull request, a children prop bug has been fixed which appeared when writing this carousel element in the typescript file. In the file named index.d.ts at 110 a children prop has been added to fix that bug as shown in the screenshots below:
<img width="1440" alt="Screenshot 2023-02-08 at 9 13 13 PM" src="https://user-images.githubusercontent.com/87875062/217622970-4ff31068-2bfc-41e2-91a2-3a8d7a8ae8d0.png">
<img width="1440" alt="Screenshot 2023-02-08 at 9 13 03 PM" src="https://user-images.githubusercontent.com/87875062/217622978-dee84bb6-8675-4fd0-8621-59cead4bbda5.png">
