### PR TITLE
Add ReactNode type to children prop and make isRTL prop optional

### DIFF
--- a/src/react-elastic-carousel/index.d.ts
+++ b/src/react-elastic-carousel/index.d.ts
@@ -34,7 +34,9 @@ export interface ReactElasticCarouselProps {
   // Defaults to false
   verticalMode?: boolean;
   // Defaults to false
-  isRTL: boolean;
+  isRTL?: boolean;
+  // adding ReactNode type to the children prop
+  children: React.ReactNode;
   // Defaults to true
   pagination?: boolean;
   // Defaults to 500


### PR DESCRIPTION
**Before resolving the type error, I encountered this issue:**  ![image](https://github.com/sag1v/react-elastic-carousel/assets/101598648/58de2e12-0cba-4c9a-94d6-a25f9111e737)
After Fix : 
![image](https://github.com/sag1v/react-elastic-carousel/assets/101598648/fb907889-da38-4757-a98a-8c8a0235085d)
 
The error can be reproduced during a build process using Next.js with TypeScript.